### PR TITLE
Fix/update function

### DIFF
--- a/R/fringe.R
+++ b/R/fringe.R
@@ -75,11 +75,13 @@ fringe_update_meta <- function(f, ...){
             ". Removing from meta.")
     args <- args[!names(args) %in% fixed]
   }
+
   info <- list(name = args$name %||% f$name,
                description = args$description %||% f$description,
                slug = args$slug %||% make_slug(args$name),
                meta = args[!names(args) %in% c("name", "description","slug")])
   f <- modifyList(f, info)
+  f$meta$sources <- args$sources %||% f$meta$sources
   f
 }
 

--- a/tests/testthat/test-fringe.R
+++ b/tests/testthat/test-fringe.R
@@ -137,5 +137,18 @@ test_that("fringe", {
   f3 <- fringe_update_meta(f0, slug = "new_mtcars")
   expect_equal(f3, f2)
 
+  sources <- list(title = "source name", path = "url-of-source")
+
+  f4 <- fringe(mtcars, sources = sources)
+  expect_equal(f4$meta$sources, sources)
+
+  sources_update <- list()
+  sources_update[[1]] <- sources
+  sources_update[[2]] <- list(title = "another source", path = "url-of-source")
+
+  f5 <- fringe_update_meta(f4, name = "this data", sources = sources_update)
+  expect_equal(f5$meta$sources, sources_update)
+  expect_equal(f5$name, "this data")
+
 })
 


### PR DESCRIPTION
The `fringe_update_meta` function was not updating parameters passed through `meta` correctly when the parameter was a list of lists (for example a list of multiple sources). 