### PR TITLE
fix has_decimal_comma function for negative numbers

### DIFF
--- a/R/guess_hdType.R
+++ b/R/guess_hdType.R
@@ -67,8 +67,9 @@ maybeNum <- function(v){
 
 has_decimal_comma <- function(v){
   v0 <- gsub("[0-9\\.]","", v)
+  v1 <- gsub("-", "", v0)
   #has_commas <- grepl(",",v0)
-  has_other_punct <- grepl("[[:punct:]]", gsub(",","", v0))
+  has_other_punct <- grepl("([-])|[[:punct:]]", gsub(",","", v1))
   if(any(has_other_punct)) return(FALSE)
   TRUE
 }


### PR DESCRIPTION
Updated `has_decimal_comma` function so that it recognizes that a number has a decimal comma when it's negative. 