### PR TITLE
as numeric input to transform in class Num homodatum

### DIFF
--- a/R/Num.R
+++ b/R/Num.R
@@ -90,6 +90,7 @@ as.character.hd_Num <- function(x) as.character(vec_data(x))
 
 #' @export
 as_Num <- function(x) {
+  x <- as.numeric(x)
   vctrs::vec_cast(x, Num())
 }
 


### PR DESCRIPTION
cuando el vector ingresado es de clase integer no es posible darle el formato Num de homodatum,
por lo que se debe pasar el vector a una clase númerica